### PR TITLE
Gemspec - replace railties with rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,21 @@ before_install:
   - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
   - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
   - "phantomjs --version"
+
 rvm:
   - 2.4.1
+
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+  # Travis should check every minor version in a range of supported versions, because
+  # rails does not follow sem-ver conventions, see http://guides.rubyonrails.org/maintenance_policy.html
+  # It should be sufficient to test only the latest of the patch versions for a minor version, they
+  # should be compatible across patch versions (only bug fixes are released in patch versions).
   matrix:
     - "RAILS_VERSION=5.0.3"
     - "RAILS_VERSION=5.1.1"
+
 services:
   - redis-server
 before_script:

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -26,6 +26,11 @@ EOF
   spec.version       = Hyrax::VERSION
   spec.license       = 'Apache2'
 
+  # Note: rails does not follow sem-ver conventions, it's
+  # minor version releases can include breaking changes; see
+  # http://guides.rubyonrails.org/maintenance_policy.html
+  spec.add_dependency 'rails', '~> 5.0'
+
   spec.add_dependency 'hydra-head', '>= 10.4.0'
   spec.add_dependency 'hydra-editor', '~> 3.3'
   spec.add_dependency 'hydra-works', '~> 0.16'
@@ -52,7 +57,6 @@ EOF
   spec.add_dependency 'flipflop', '~> 2.3'
   spec.add_dependency 'jquery-datatables-rails', '~> 3.4.0'
   spec.add_dependency 'rdf-rdfxml' # controlled vocabulary importer
-  spec.add_dependency 'railties', '~> 5.0'
   spec.add_dependency 'clipboard-rails', '~> 1.5'
   spec.add_dependency 'rails_autolink', '~> 1.1'
   spec.add_dependency 'active_fedora-noid', '~> 2.0', '>= 2.0.2'


### PR DESCRIPTION
Fixes https://github.com/projecthydra-labs/hyrax/issues/1028 

It's all described in #1028 and associated issues noted there.  The current range of rails versions allowed is any `5.0.x` up to `5.1.x` (excluding anything beyond `5.2` until it is tested).

@projecthydra-labs/hyrax-code-reviewers

Tagging commentators from #1007 - @mjgiarlo, @jcoyne, @cbeer, @jrochkind 

I get a successful bundle install and travis is testing this range of rails versions already, i.e.
```
$ rm -rf Gemfile.lock .internal_test_app
$ bundle install --quiet && echo 'success' || echo 'failed'
success
```

- [x] debate over the details of the rails version pin resolved to use `~> 5.0`
- [x] bump the hyrax version and release a new gem for this PR?
  - @mjgiarlo notes in slack that we don't need to bump for this
- [x] squash commits
- [x] cut a branch/release that is pinned to rails `~> 4.0`, using a release point that works on 4.x?
  - @mjgiarlo notes below that hyrax will not support rails 4.x
