### PR TITLE
Remove to_param implementation that was just used in unit tests

### DIFF
--- a/app/services/hyrax/noid.rb
+++ b/app/services/hyrax/noid.rb
@@ -10,11 +10,6 @@ module Hyrax
       service.mint if Hyrax.config.enable_noids?
     end
 
-    # @todo Do we need this here? I'm a bit surprised to see it here [JNF]
-    def to_param
-      id
-    end
-
     private
 
       def service

--- a/spec/controllers/hyrax/admin/admin_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/admin_sets_controller_spec.rb
@@ -68,6 +68,8 @@ RSpec.describe Hyrax::Admin::AdminSetsController do
         let(:service) do
           lambda do |admin_set:, **_kargs|
             admin_set.id = 123
+            # https://github.com/projecthydra/active_fedora/issues/1251
+            allow(admin_set).to receive(:persisted?).and_return(true)
             true
           end
         end

--- a/spec/controllers/hyrax/api/items_controller_spec.rb
+++ b/spec/controllers/hyrax/api/items_controller_spec.rb
@@ -121,6 +121,8 @@ RSpec.describe Hyrax::API::ItemsController, type: :controller do
       before do
         # Mock arkivo actor functions
         allow(arkivo_actor).to receive(:create_work_from_item).and_return(a_work)
+        # https://github.com/projecthydra/active_fedora/issues/1251
+        allow(a_work).to receive(:persisted?).and_return(true)
       end
 
       it "delegates creating the work to the actor" do

--- a/spec/controllers/hyrax/permissions_controller_spec.rb
+++ b/spec/controllers/hyrax/permissions_controller_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe Hyrax::PermissionsController do
   describe '#confirm' do
     let(:work) { build(:generic_work, user: user, id: 'abc') }
 
+    before do
+      # https://github.com/projecthydra/active_fedora/issues/1251
+      allow(work).to receive(:persisted?).and_return(true)
+    end
+
     it 'draws the page' do
       get :confirm, params: { id: work }
       expect(response).to be_success

--- a/spec/indexers/hyrax/file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/file_set_indexer_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe Hyrax::FileSetIndexer do
 
   describe '#generate_solr_document' do
     before do
+      # https://github.com/projecthydra/active_fedora/issues/1251
+      allow(file_set).to receive(:persisted?).and_return(true)
       allow(file_set).to receive(:label).and_return('CastoriaAd.tiff')
       allow(Hyrax::ThumbnailPathService).to receive(:call).and_return('/downloads/foo123?file=thumbnail')
       allow(file_set).to receive(:original_file).and_return(mock_file)

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe Hyrax::FileSetPresenter do
   let(:user) { double(user_key: 'sarah') }
 
   describe 'stats_path' do
+    before do
+      # https://github.com/projecthydra/active_fedora/issues/1251
+      allow(file).to receive(:persisted?).and_return(true)
+    end
     it { expect(presenter.stats_path).to eq Hyrax::Engine.routes.url_helpers.stats_file_path(id: file) }
   end
 

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe Hyrax::WorkShowPresenter do
     let(:user) { 'sarah' }
     let(:ability) { double "Ability" }
     let(:work) { build(:generic_work, id: '123abc') }
+    before do
+      # https://github.com/projecthydra/active_fedora/issues/1251
+      allow(work).to receive(:persisted?).and_return(true)
+    end
     let(:attributes) { work.to_solr }
     it { expect(presenter.stats_path).to eq Hyrax::Engine.routes.url_helpers.stats_work_path(id: work) }
   end

--- a/spec/services/hyrax/noid_spec.rb
+++ b/spec/services/hyrax/noid_spec.rb
@@ -10,12 +10,6 @@ RSpec.describe Hyrax::Noid do
   end
   let(:object) { class_with_noids.new(id: 1234) }
 
-  describe '#to_param' do
-    it "will be the object's id" do
-      expect(object.to_param).to eq(object.id)
-    end
-  end
-
   describe 'when noids are not enabled' do
     before { expect(Hyrax.config).to receive(:enable_noids?).and_return(false) }
     subject { object.assign_id }

--- a/spec/services/hyrax/thumbnail_path_service_spec.rb
+++ b/spec/services/hyrax/thumbnail_path_service_spec.rb
@@ -5,7 +5,11 @@ RSpec.describe Hyrax::ThumbnailPathService do
 
   context "with a FileSet" do
     let(:object) { build(:file_set, id: '999') }
-    before { allow(object).to receive(:original_file).and_return(original_file) }
+    before do
+      allow(object).to receive(:original_file).and_return(original_file)
+      # https://github.com/projecthydra/active_fedora/issues/1251
+      allow(object).to receive(:persisted?).and_return(true)
+    end
     context "that has a thumbnail" do
       let(:original_file) { mock_file_factory(mime_type: 'image/jpeg') }
       before { allow(File).to receive(:exist?).and_return(true) }

--- a/spec/views/hyrax/homepage/_sortable_featured.html.erb_spec.rb
+++ b/spec/views/hyrax/homepage/_sortable_featured.html.erb_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'hyrax/homepage/_sortable_featured.html.erb', type: :view do
   let(:page)          { rendered }
 
   before do
+    # https://github.com/projecthydra/active_fedora/issues/1251
+    allow(work).to receive(:persisted?).and_return(true)
     allow(view).to receive(:f).and_return(form_builder)
     allow(form_builder).to receive(:object).and_return(featured_work)
     allow(form_builder).to receive(:hidden_field)


### PR DESCRIPTION
This override was here in the first place because the default
implementation of to_param in ActiveModel requires the object to
be persisted.

We should fix this upstream:
https://github.com/projecthydra/active_fedora/issues/1251
