### PR TITLE
solr & fedora configs for wrappers

### DIFF
--- a/.fcrepo_wrapper
+++ b/.fcrepo_wrapper
@@ -1,0 +1,4 @@
+# Place any default configuration for fcrepo_wrapper here
+port: 8984
+enable_jms: false
+fcrepo_home_dir: tmp/fcrepo4-development-data

--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,0 +1,6 @@
+# Place any default configuration for solr_wrapper here
+# port: 8983
+collection:
+  persist: true
+  dir: solr/config/
+  name: hydra-development


### PR DESCRIPTION
Hyrax should manage it's own Solr/Fedora configs for the solr_wrapper and fcrepo_wrapper.

Changes proposed in this pull request:
- add .fcrepo_wrapper
  - copied some values from `.internal_test_app/.fcrepo_wrapper`
- add .solr_wrapper
  - copied some values from `.internal_test_app/.solr_wrapper`

This makes it possible to call the wrappers from the hyrax repo checkout, rather than cd into the internal test app, to run Solr/Fedora in a separate window.

@projecthydra-labs/hyrax-code-reviewers
