### PR TITLE
1.0.x backport: Relax active_attr dependency specification

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dry-validation', '~> 0.9'
   spec.add_dependency 'dry-equalizer', '~> 0.2'
   spec.add_dependency 'dry-struct', '~> 0.1'
-  spec.add_dependency 'active_attr', '~> 0.9.0'
+  spec.add_dependency 'active_attr', '~> 0.9'
   spec.add_dependency 'redlock', '~> 0.1.2'
   spec.add_dependency 'retriable', '>= 2.9', '< 4.0'
   spec.add_dependency 'active-fedora', '>= 11.1.3'


### PR DESCRIPTION
Otherwise `bundle install` errors with:
```
hyrax was resolved to 1.0.1, which depends on
  active_attr (~> 0.9.0) was resolved to 0.9.0, which depends on
    activesupport (< 5.1, >= 3.0.2)
```

@samvera-labs/hyrax-code-reviewers
