### PR TITLE
Give a helpful warning about missing permission template

### DIFF
--- a/lib/tasks/default_admin_set.rake
+++ b/lib/tasks/default_admin_set.rake
@@ -2,7 +2,18 @@ namespace :hyrax do
   namespace :default_admin_set do
     desc "Create the Default Admin Set"
     task create: :environment do
-      AdminSet.find_or_create_default_admin_set_id
+      id = AdminSet.find_or_create_default_admin_set_id
+      unless Hyrax::PermissionTemplate.find_by(admin_set_id: id)
+        $stderr.puts "ERROR: Default admin set exists but it does not have an " \
+          "associated permission template.\n\nThis may happen if you cleared your " \
+          "database but you did not clear out Fedora and Solr.\n\n" \
+          "You could manually create the permission template in the rails console" \
+          " (non-destructive):\n\n" \
+          "    Hyrax::PermissionTemplate.create!(admin_set_id: AdminSet::DEFAULT_ID)\n\n" \
+          "OR you could start fresh by clearing Fedora and Solr (destructive):\n\n" \
+          "    require 'active-fedora/cleaner'\n" \
+          "    ActiveFedora::Cleaner.clean!\n\n"
+      end
     end
   end
 end


### PR DESCRIPTION
```
$ rake hyrax:default_admin_set:create
ERROR: Default admin set exists but it does not have an associated permission template.

This may happen if you cleared your database but you did not clear out Fedora and Solr.

You could manually create the permission template in the rails console (non-destructive):

    Hyrax::PermissionTemplate.create!(admin_set_id: AdminSet::DEFAULT_ID)

OR you could start fresh by clearing Fedora and Solr (destructive):

    require 'active-fedora/cleaner'
    ActiveFedora::Cleaner.clean!
```