### PR TITLE
Raise StandardError when a data file can't be found

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -6,7 +6,7 @@ class CharacterizeJob < Hyrax::ApplicationJob
   # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
   def perform(file_set, file_id, filepath = nil)
     filename = Hyrax::WorkingDirectory.find_or_retrieve(file_id, file_set.id, filepath)
-    raise LoadError, "#{file_set.class.characterization_proxy} was not found" unless file_set.characterization_proxy?
+    raise "#{file_set.class.characterization_proxy} was not found" unless file_set.characterization_proxy?
     Hydra::Works::CharacterizationService.run(file_set.characterization_proxy, filename)
     Rails.logger.debug "Ran characterization on #{file_set.characterization_proxy.id} (#{file_set.characterization_proxy.mime_type})"
     file_set.characterization_proxy.save!

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CharacterizeJob do
   context 'when the characterization proxy content is absent' do
     before { allow(file_set).to receive(:characterization_proxy?).and_return(false) }
     it 'raises an error' do
-      expect { described_class.perform_now(file_set, file.id) }.to raise_error(LoadError, 'original_file was not found')
+      expect { described_class.perform_now(file_set, file.id) }.to raise_error(StandardError, 'original_file was not found')
     end
   end
 


### PR DESCRIPTION
LoadError should be used when loading code, not when a data file doesn't
exist.  See https://ruby-doc.org/core-2.4.1/LoadError.html
