### PR TITLE
Add facet path for dashboard/works.

### DIFF
--- a/app/controllers/hyrax/dashboard/works_controller.rb
+++ b/app/controllers/hyrax/dashboard/works_controller.rb
@@ -19,6 +19,11 @@ module Hyrax
         def search_action_url(*args)
           hyrax.dashboard_works_url(*args)
         end
+
+        # The url of the "more" link for additional facet values
+        def search_facet_path(args = {})
+          hyrax.dashboard_works_facet_path(args[:id])
+        end
     end
   end
 end

--- a/app/views/hyrax/my/_facet_limit.html.erb
+++ b/app/views/hyrax/my/_facet_limit.html.erb
@@ -1,4 +1,4 @@
-  <ul class="<%= 'dropdown-menu ' if request.format.html? %>facet-values" aria-labelledby="<%= facet_field.field.parameterize %>">
+  <ul class="<%= 'dropdown-menu ' if action_name == 'index' %>facet-values" aria-labelledby="<%= facet_field.field.parameterize %>">
     <% paginator = facet_paginator(facet_field, display_facet) %>
     <%= render_facet_limit_list paginator, facet_field.key %>
 

--- a/app/views/hyrax/my/_facet_limit.html.erb
+++ b/app/views/hyrax/my/_facet_limit.html.erb
@@ -1,4 +1,4 @@
-  <ul class="dropdown-menu facet-values" aria-labelledby="<%= facet_field.field.parameterize %>">
+  <ul class="<%= 'dropdown-menu ' if request.format.html? %>facet-values" aria-labelledby="<%= facet_field.field.parameterize %>">
     <% paginator = facet_paginator(facet_field, display_facet) %>
     <%= render_facet_limit_list paginator, facet_field.key %>
 

--- a/app/views/hyrax/my/_facet_limit.html.erb
+++ b/app/views/hyrax/my/_facet_limit.html.erb
@@ -1,3 +1,7 @@
+  <%# This template is used to render the initial facet list (#index action)
+      and a paginated facet list in a modal (#facet action). The `dropdown-menu`
+      class in only necessary for the former and causes display issues in the latter.
+  -%>
   <ul class="<%= 'dropdown-menu ' if action_name == 'index' %>facet-values" aria-labelledby="<%= facet_field.field.parameterize %>">
     <% paginator = facet_paginator(facet_field, display_facet) %>
     <%= render_facet_limit_list paginator, facet_field.key %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,7 @@ Hyrax::Engine.routes.draw do
 
   namespace :dashboard do
     resources :works, only: :index
+    get 'works/facet/:id',  controller: 'works', action: :facet, as: 'works_facet'
     resources :collections, only: :index
     resources :profiles, only: [:show, :edit, :update]
   end

--- a/spec/controllers/hyrax/dashboard/works_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/works_controller_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe Hyrax::Dashboard::WorksController, type: :controller do
+  describe "#search_builder_class" do
+    subject { controller.search_builder_class }
+    it { is_expected.to eq Hyrax::WorksSearchBuilder }
+  end
+
+  describe "#search_facet_path" do
+    subject { controller.send(:search_facet_path, id: 'keyword_sim') }
+    it { is_expected.to eq "/dashboard/works/facet/keyword_sim?locale=en" }
+  end
+end


### PR DESCRIPTION
Fixes #1107 

Clicking the "More" link for facets in the "All Works" tab under Dashboard -> Works renders a modal with incorrect facet values and/or counts.

Changes proposed in this pull request:
* Define `search_facet_path` for `dashboard/works_controller.rb`
* Do not use `dropdown-menu` class inside facet modal.

@samvera-labs/hyrax-code-reviewers
