### PR TITLE
RSpec configuration to fail fast when running on travis.ci

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -147,6 +147,8 @@ require 'active_fedora/cleaner'
 RSpec.configure do |config|
   include ActiveFedora::Noid::RSpec
 
+  config.fail_fast = true if ENV['TRAVIS']
+
   config.disable_monkey_patching!
   config.include Shoulda::Matchers::ActiveRecord, type: :model
 


### PR DESCRIPTION
An alternative implementation to speed up travis builds, fix #1117

Changes proposed in this pull request:
*  rspec configuration to fail-fast, only on travis

@samvera-labs/hyrax-code-reviewers
