### PR TITLE
Make collection edit page wording consistent

### DIFF
--- a/app/views/hyrax/base/_form_share.html.erb
+++ b/app/views/hyrax/base/_form_share.html.erb
@@ -48,7 +48,7 @@
   </div>
   <div class="col-sm-4">
     <label for="new_user_permission_skel" class="sr-only">Access type to grant</label>
-    <%= select_tag 'new_user_permission_skel', options_for_select(Hyrax.config.permission_levels), class: 'form-control' %>
+    <%= select_tag 'new_user_permission_skel', options_for_select(Hyrax.config.permission_options), class: 'form-control' %>
   </div>
   <div class="col-sm-3">
     <button class="btn btn-default" id="add_new_user_skel">
@@ -68,7 +68,7 @@
   </div>
   <div class="col-sm-4">
     <label for="new_group_permission_skel" class="sr-only">Access type to grant</label>
-    <%= select_tag 'new_group_permission_skel', options_for_select(Hyrax.config.permission_levels), class: 'form-control' %>
+    <%= select_tag 'new_group_permission_skel', options_for_select(Hyrax.config.permission_options), class: 'form-control' %>
   </div>
   <div class="col-sm-3">
     <span class="sr-only">Add this group</span>

--- a/app/views/hyrax/collections/_form_share.html.erb
+++ b/app/views/hyrax/collections/_form_share.html.erb
@@ -6,7 +6,7 @@
   </legend>
 
   <div class="alert alert-info hidden" id="save_perm_note">Permissions are
-  <strong>not</strong> saved until the &quot;Save&quot; button is pressed at the bottom of the page.</div>
+  <strong>not</strong> saved until the &quot;Update Collection&quot; button is pressed at the bottom of the page.</div>
 
   <div class="alert alert-warning hidden" role="alert" id="permissions_error">
     <span id="permissions_error_text"></span>
@@ -52,7 +52,7 @@
     </div>
     <div class="col-sm-4">
       <label for="new_user_permission_skel" class="sr-only">Access type to grant</label>
-      <%= select_tag 'new_user_permission_skel', options_for_select(Hyrax.config.permission_levels), class: 'form-control' %>
+      <%= select_tag 'new_user_permission_skel', options_for_select(Hyrax.config.permission_options), class: 'form-control' %>
     </div>
     <div class="col-sm-3">
       <button class="btn btn-default" id="add_new_user_skel">
@@ -72,7 +72,7 @@
     </div>
     <div class="col-sm-4">
       <label for="new_group_permission_skel" class="sr-only">Access type to grant</label>
-      <%= select_tag 'new_group_permission_skel', options_for_select(Hyrax.config.permission_levels), class: 'form-control' %>
+      <%= select_tag 'new_group_permission_skel', options_for_select(Hyrax.config.permission_options), class: 'form-control' %>
     </div>
     <div class="col-sm-3">
       <span class="sr-only">Add this group</span>

--- a/app/views/hyrax/file_sets/_permission_form.html.erb
+++ b/app/views/hyrax/file_sets/_permission_form.html.erb
@@ -34,7 +34,7 @@
     </div>
     <div class="col-sm-4">
       <label for="new_user_permission_skel" class="sr-only">Access type to grant</label>
-      <%= select_tag 'new_user_permission_skel', options_for_select(Hyrax.config.permission_levels), class: 'form-control' %>
+      <%= select_tag 'new_user_permission_skel', options_for_select(Hyrax.config.permission_options), class: 'form-control' %>
     </div>
     <div class="col-sm-3">
       <button class="btn btn-default" id="add_new_user_skel">
@@ -55,7 +55,7 @@
     </div>
     <div class="col-sm-4">
       <label for="new_group_permission_skel" class="sr-only">Access type to grant</label>
-      <%= select_tag 'new_group_permission_skel', options_for_select(Hyrax.config.permission_levels), class: 'form-control' %>
+      <%= select_tag 'new_group_permission_skel', options_for_select(Hyrax.config.permission_options), class: 'form-control' %>
     </div>
     <div class="col-sm-3">
       <span class="sr-only">Add this group</span>

--- a/lib/generators/hyrax/templates/config/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/hyrax.rb
@@ -135,8 +135,11 @@ Hyrax.config do |config|
   #   @see Hyrax::LicenseService for implementation details
   # config.license_service_class = Hyrax::LicenseService
 
-  # Labels for permission levels
-  # config.permission_levels = { "Choose Access" => "none", "View/Download" => "read", "Edit" => "edit" }
+  # Labels for display of permission levels
+  # config.permission_levels = { "View/Download" => "read", "Edit access" => "edit" }
+
+  # Labels for permission level options used in dropdown menus
+  # config.permission_options = { "Choose Access" => "none", "View/Download" => "read", "Edit" => "edit" }
 
   # Labels for owner permission levels
   # config.owner_permission_levels = { "Edit Access" => "edit" }

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -381,14 +381,20 @@ module Hyrax
 
     attr_writer :permission_levels
     def permission_levels
-      @permission_levels ||= { "Choose Access" => "none",
-                               "View/Download" => "read",
-                               "Edit" => "edit" }
+      @permission_levels ||= { "View/Download" => "read",
+                               "Edit access" => "edit" }
     end
 
     attr_writer :owner_permission_levels
     def owner_permission_levels
-      @owner_permission_levels ||= { "Edit Access" => "edit" }
+      @owner_permission_levels ||= { "Edit access" => "edit" }
+    end
+
+    attr_writer :permission_options
+    def permission_options
+      @permission_options ||= { "Choose Access" => "none",
+                                "View/Download" => "read",
+                                "Edit" => "edit" }
     end
 
     attr_writer :translate_uri_to_id

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:model_to_create) }
   it { is_expected.to respond_to(:owner_permission_levels) }
   it { is_expected.to respond_to(:permission_levels) }
+  it { is_expected.to respond_to(:permission_options) }
   it { is_expected.to respond_to(:persistent_hostpath) }
   it { is_expected.to respond_to(:redis_namespace) }
   it { is_expected.to respond_to(:subject_prefix) }


### PR DESCRIPTION
Fixes https://github.com/samvera-labs/hyrax/issues/1020

* Change "save" button text to refer to "update collection".
* Make "Edit" and "Edit Access" showing of permissions both say
"Edit access"
* Add a new method (permission_options), to be used for the dropdown selection of rights.
* Apply the new method to all partials which use a dropdown selection of rights.

@samvera-labs/hyrax-code-reviewers
