### PR TITLE
Preserve the filename on imported urls

### DIFF
--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -117,6 +117,7 @@ module Hyrax
           if file.respond_to?(:original_filename)
             file.original_filename
           elsif file_set.import_url.present?
+            # This path is taken when file is a Tempfile (e.g. from ImportUrlJob)
             File.basename(Addressable::URI.parse(file_set.import_url).path)
           else
             File.basename(file)

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ImportUrlJob do
     end
 
     it 'creates the content and updates the associated operation' do
-      expect(actor).to receive(:create_content).with(Tempfile, 'original_file', false).and_return(true)
+      expect(actor).to receive(:create_content).with(File, 'original_file', false).and_return(true)
       described_class.perform_now(file_set, operation)
       expect(operation).to be_success
     end


### PR DESCRIPTION
Previously the metadata was recording the random path (from Tempfile) as
the original file name.

Fixes #1172
