### PR TITLE
Add new feature toggle allowing disabling account creation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -136,6 +136,7 @@ RSpec/MessageSpies:
 RSpec/InstanceVariable:
   Exclude:
     - 'spec/services/hyrax/derivative_service_spec.rb'
+    - 'spec/controllers/hyrax/registrations_controller_spec.rb'
 
 RSpec/ExpectActual:
   Enabled: false

--- a/app/controllers/hyrax/registrations_controller.rb
+++ b/app/controllers/hyrax/registrations_controller.rb
@@ -1,0 +1,15 @@
+module Hyrax
+  class RegistrationsController < Devise::RegistrationsController
+    def new
+      return super if Flipflop.account_signup?
+      flash[:alert] = t(:'hyrax.account_signup')
+      redirect_to root_path
+    end
+
+    def create
+      return super if Flipflop.account_signup?
+      flash[:alert] = t(:'hyrax.account_signup')
+      redirect_to root_path
+    end
+  end
+end

--- a/config/features.rb
+++ b/config/features.rb
@@ -30,4 +30,8 @@ Flipflop.configure do
   feature :batch_upload,
           default: true,
           description: "Enable uploading batches of works"
+
+  feature :account_signup,
+          default: true,
+          description: 'Enable users to sign up for accounts'
 end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -54,6 +54,7 @@ en:
       update: 'Save'
   hyrax:
     account_label:      "User"
+    account_signup:     'Account registration is disabled'
     active_consent_to_agreement:  "I have read and agree to the"
     admin:
       admin_sets:

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -54,6 +54,7 @@ es:
       update: 'Guardar'
   hyrax:
     account_label:      "Usuario"
+    account_signup:     'El registro de la cuenta está deshabilitado'
     active_consent_to_agreement:  "He leído y estoy de acuerdo con"
     admin:
       admin_sets:

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -56,6 +56,7 @@ zh:
       update: '保存'
   hyrax:
     account_label:  "用户"
+    account_signup: '帐户注册被禁用'
     active_consent_to_agreement:  "我已经阅读并同意"
     admin:
       admin_sets:

--- a/spec/controllers/hyrax/registrations_controller_spec.rb
+++ b/spec/controllers/hyrax/registrations_controller_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe Hyrax::RegistrationsController, type: :controller do
+  routes { Rails.application.routes }
+
+  before do
+    allow(Flipflop).to receive(:account_signup?).and_return(account_signup_enabled)
+    # Recommended by Devise: https://github.com/plataformatec/devise/wiki/How-To:-Test-controllers-with-Rails-3-and-4-%28and-RSpec%29
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+  end
+
+  context 'with account signup enabled' do
+    let(:account_signup_enabled) { true }
+    describe '#new' do
+      it 'renders the form' do
+        get :new
+        expect(response).to render_template('devise/registrations/new')
+      end
+    end
+    describe '#create' do
+      it 'processes the form' do
+        post :create, params: { user: { email: "user@example.org", password: "password", password_confirmation: "password" } }
+        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en')
+        expect(flash[:notice]).to eq 'Welcome! You have signed up successfully.'
+      end
+    end
+  end
+  context 'with account signup disabled' do
+    let(:account_signup_enabled) { false }
+    describe '#new' do
+      it 'redirects with a flash message' do
+        get :new
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq 'Account registration is disabled'
+      end
+    end
+    describe '#create' do
+      it 'redirects with a flash message' do
+        post :create
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq 'Account registration is disabled'
+      end
+    end
+  end
+end

--- a/spec/models/flipflop_spec.rb
+++ b/spec/models/flipflop_spec.rb
@@ -26,4 +26,11 @@ RSpec.describe Flipflop do
       is_expected.to be true
     end
   end
+
+  describe "account_signup?" do
+    subject { described_class.account_signup? }
+    it "defaults to true" do
+      is_expected.to be true
+    end
+  end
 end

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -67,4 +67,8 @@ class TestAppGenerator < Rails::Generators::Base
   def relax_routing_constraint
     gsub_file 'config/initializers/arkivo_constraint.rb', 'false', 'true'
   end
+
+  def override_devise_registrations_controller
+    gsub_file 'config/routes.rb', 'devise_for :users', 'devise_for :users, controllers: { registrations: "hyrax/registrations" }'
+  end
 end


### PR DESCRIPTION
When account creation is disabled, redirect to the homepage with an alert. When enabled, let Devise do its thing. This implementation relies on a small routing change that lets Hyrax override two methods in the Devise RegistrationsController. I am on the fence as to whether Hyrax should automatically handle this for users (i.e., we should move the code from the test_app_generator to the install_generator), or if we should rely on documentation and release notes for this. There is a chance that this flipper will be made available in instances that have not made this routing change, which would be misleading for users.

Refs samvera-labs/hyku#1203

@samvera-labs/hyrax-code-reviewers
