### PR TITLE
Batch create should have same sharing behavior as single

### DIFF
--- a/app/views/hyrax/base/_guts4form.html.erb
+++ b/app/views/hyrax/base/_guts4form.html.erb
@@ -33,6 +33,7 @@
             <div role="tabpanel" class="tab-pane" id="<%= tab %>">
           <% end %>
             <div class="form-tab-content">
+              <% # metadata_tab is sometimes provided %>
               <%= yield "#{tab}_tab".to_sym if content_for? "#{tab}_tab".to_sym %>
               <%= render "form_#{tab}", f: f %>
             </div>

--- a/app/views/hyrax/batch_uploads/_form.html.erb
+++ b/app/views/hyrax/batch_uploads/_form.html.erb
@@ -10,8 +10,7 @@
       <%= link_to t("hyrax.batch_uploads.files.button_label"), [main_app, :new, Hyrax.primary_work_type.model_name.singular_route_key] %>
     </p>
   <% end %>
-  <%= render 'hyrax/base/guts4form', f: f, tabs: %w[files metadata relationships share] do %>
-  <% end %>
+  <%= render 'hyrax/base/guts4form', f: f, tabs: %w[files metadata relationships] %>
   <%= f.hidden_field :payload_concern, value: @form.payload_concern %>
 <% end %>
 


### PR DESCRIPTION
The batch create hadn't yet been fixed so that a share tab only displays
when an admin set that has direct deposit is chosen. We don't want the
depositor to share edit access on something that goes through mediated
deposit.

Prior to this change the batch upload screen could get two sharing tabs.

Ref https://github.com/samvera-labs/hyku/issues/1195
